### PR TITLE
Quickfix flat loss plots for model.fit_generator()

### DIFF
--- a/live_loss_plot.py
+++ b/live_loss_plot.py
@@ -24,7 +24,7 @@ class PlotLosses(Callback):
         self.logs = []
 
     def on_epoch_end(self, epoch, logs={}):
-        self.logs.append(logs)
+        self.logs.append(logs.copy())
 
         clear_output(wait=True)
         plt.figure(figsize=self.figsize)


### PR DESCRIPTION
Append a shallow copy of the 'logs' variable instead of the 'logs' variable itself. Fixes issue of flat plots when using keras model.fit_generator().